### PR TITLE
inmates#17: "fixes shell output"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ scraper-run:
 	@$(VENV_PYTHON) $(SCRAPERDIR) $$LIVESITE_PARSED_OUTPUT_DIR
 
 new-spider:
-	@$(VENV_PYTHON) -m scrapy genspider -t init $(NAME) - $(shell if [ $(FORCE) = true ]; then echo "--force"; fi )
+	@$(VENV_PYTHON) -m scrapy genspider -t init $(NAME) - $(if $(FORCE), --force)
 
 
 targets:


### PR DESCRIPTION
# Summary
the `make new-spider` command would output the following without the FORCE flag:
```
/bin/sh: line 0: [: =: unary operator expected
```

# Testing
* run `make new-spider NAME=hello` without issue
* run `make new-spider NAME=hello FORCE=true` without issue