### PR TITLE
inmates#46: "install respects restrictive file permisions"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,6 @@ uninstall: $(VENV) $(VENV_PYTHON) clean-install
 .PHONY: venv # builds the virtual environment
 venv:
 	@if [ ! -d $(VENV) ]; then \
-		$(SYSTEM_PYTHON) -m pip install virtualenv; \
+		$(SYSTEM_PYTHON) -m pip install virtualenv --user; \
 		$(SYSTEM_PYTHON) -m virtualenv $(VENV) >/dev/null; \
 	fi


### PR DESCRIPTION
addresses #46

merging contingent upon approval by @Pol-S and @rdasika.

# Testing
* ensure you system `python3` _does not_ have `virtualenv` installed (run `pip3 uninstall virtualenv`)
* run `make`
* install should be uneventful and not require sudo